### PR TITLE
[Docs] Add direct link for code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ If you're interested in working on any of the issues, please let us know by subm
 <br>
 <h2 align="center">Code of Conduct 💚</h2>
 
-Contributors are expected to adhere to the following Code of Conduct to ensure a positive and inclusive environment for collaboration
+Contributors are expected to adhere to the following [Code of Conduct](https://github.com/ssitvit/Games-and-Go/blob/main/CODE_OF_CONDUCT.md) to ensure a positive and inclusive environment for collaboration
 	
 If you want to get free **T-shirt,Swags** like **developers** then contribute and grow this repository with us, make sure to check out Contributing.md for contribution guidelines and add your name in the Readme.md and Contributors.md.  <br/>
 </p>


### PR DESCRIPTION
This pr add a direct link for `CODE_OF_CONDUCT.md` to improve the user experience of the documentation.  

Fixes #763

before: 
![image](https://github.com/ssitvit/Games-and-Go/assets/129386460/ec1b4670-92dc-4cc9-97e1-ed49b5d66efc)
after:
![image](https://github.com/ssitvit/Games-and-Go/assets/129386460/2df166d5-9cc7-45af-82b0-7a27faebaa03)
 