### PR TITLE
fix: invisible "game on" heading during theme toggle ⚒️✨ 

### DIFF
--- a/src/Homepage/Homepage/Homepage.css
+++ b/src/Homepage/Homepage/Homepage.css
@@ -705,3 +705,8 @@ input.search-input:hover {
   color: #96969c !important;
 }
 
+.header_homepage h1 {
+  font-size: 3.5rem;
+  width: 100%;
+  color: white;
+}


### PR DESCRIPTION
# Close #963 

## Screenshots
|BEFORE|AFTER|
|:---:|:---:|
| ![](https://user-images.githubusercontent.com/92252895/258689338-e6d3146f-6384-4d1d-9aad-9c08d0a9f242.png) | ![image](https://github.com/ssitvit/Games-and-Go/assets/92252895/807f46f7-1c62-477c-ba0f-7ec3517f3675) |
