### PR TITLE
feat: made gssoc banner responsive to github light/dark mode 🌞/🌚 💡✨  

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,27 @@
 
  ---
  
- ### OPEN SOURCE CONTRIBUTIONS!!  
-<p align="center">
-    <img src="https://miro.medium.com/max/1400/1*fqJaH_oISOR96gLgpJBwWQ.png" />
-</p>
+ ## OPEN SOURCE CONTRIBUTIONS 🎉 !!  
+ 
+<div align="center">
+	
+  <picture>
+    <source 
+	    media="(prefers-color-scheme: light)" 
+	    srcset="https://raw.githubusercontent.com/GirlScriptSummerOfCode/MentorshipProgram/master/GSsoc%20Type%20Logo%20Black.png"
+    >
+    <source 
+	    media="(prefers-color-scheme: dark)" 
+	    srcset="https://user-images.githubusercontent.com/63473496/213306279-338f7ce9-9a9f-4427-8c2a-3e344874498f.png"
+    >
+    <img 
+	    alt="Girlscript Summer of Code" 
+	    width=80% 
+	    src="https://user-images.githubusercontent.com/63473496/213306279-338f7ce9-9a9f-4427-8c2a-3e344874498f.png"
+    >
+  </picture>
+  
+</div>
 
 ---
 


### PR DESCRIPTION
## Close #1014 

## Screenshots

|LIGHT MODE|DARK MODE|
|:--:|:--:|
|![image](https://github.com/ssitvit/Games-and-Go/assets/92252895/f5cc85fb-4859-4dab-a652-fac24d864d60)|![image](https://github.com/ssitvit/Games-and-Go/assets/92252895/bf685aeb-9705-4ce0-a491-b50c09186166)|
