### PR TITLE
fixed audio not playing while toggling between themes homepage

### DIFF
--- a/src/Homepage/Homepage/DarkModeToggle.js
+++ b/src/Homepage/Homepage/DarkModeToggle.js
@@ -1,23 +1,17 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import { MdSunny, MdBrightness2 } from "react-icons/md";
-
+import audio_light_on  from "./audio_light-on.mp3"
+import audio_light_off  from "./audio_light-off.mp3"
 
 export default function ThemeSwitcher() {
   const [isDarkMode, setIsDarkMode] = useState(false);
 
   const toggleTheme = () => {
       setIsDarkMode((prevMode) => {
-        let audio;
-  
-        if (prevMode) {
-          audio = document.querySelector('.switch--on');
-        } else {
-          audio = document.querySelector('.switch--off');
-        }
-  
-        audio.currentTime = 0;
-        audio.play();
+
+        const audio = new Audio(prevMode ? audio_light_on : audio_light_off)
+        audio.play()
   
         return !prevMode;
     });
@@ -51,8 +45,6 @@ export default function ThemeSwitcher() {
         <button onClick={toggleTheme}>
           {isDarkMode ? <MdSunny/>: <MdBrightness2/>}
         </button>
-        <audio className="switch--on" src="./audio_light-on.mp3" />
-        <audio className="switch--off" src="./audio_light-off.mp3" />
       </div>
     </Wrapper>
   );


### PR DESCRIPTION
Issue - The theme toggle button on homepage not playing audio and throwing following error

![1](https://github.com/ssitvit/Games-and-Go/assets/100110348/21d20c4d-e79c-4d09-8757-0c1d4d62a4db)

Workflow - 
- Audio tag could not find source
- Added fix to use new Audio and reduced LOC
